### PR TITLE
Add __getitem__ and __setitem__ to wrapped methods

### DIFF
--- a/subredis.py
+++ b/subredis.py
@@ -50,6 +50,8 @@ def directProxy(cls, fn_name):
 def subredis_wrapper():
     def decorator(cls):
         mapping = [
+            ('__getitem__', keyProxy),
+            ('__setitem__', keyProxy),
             ('hget', keyProxy),
             ('append', keyProxy),
             # bgrewriteaof not supported for subredis

--- a/tests/redisspy.py
+++ b/tests/redisspy.py
@@ -12,6 +12,8 @@ class RedisSpy(object):
     """ Report on how "redis" is being called
         in testing"""
     def __init__(self):
+        self.addSpy("__getitem__")
+        self.addSpy("__setitem__")
         self.addSpy("append")
         self.addSpy("bitcount")
         self.addSpy("blpop")

--- a/tests/test_withredis.py
+++ b/tests/test_withredis.py
@@ -40,3 +40,14 @@ def test_keys():
     assert "cats" in keys
     print (repr(keys))
     assert len(keys) == 3
+
+
+def test_set_get():
+    subredis = SubRedis("prefix", r)
+    r.set("unrelated", "unrelated")
+    subredis.set("foo", "bar")
+    subredis["baz"] = "snaz"
+    assert subredis["foo"] == b"bar"
+    assert subredis.get("foo") == b"bar"
+    assert subredis["baz"] == b"snaz"
+    assert subredis.get("baz") == b"snaz"


### PR DESCRIPTION
This allows for using the subredis[key] format instead of only subredis.get(key) and subredis.set(key).  Tested on 3.4.3 and 2.7.5.
